### PR TITLE
Fix version number to be greater than latest release.

### DIFF
--- a/.github/workflows/gocept.amqprun.yml
+++ b/.github/workflows/gocept.amqprun.yml
@@ -43,11 +43,10 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pip install -U setuptools zc.buildout setuptools-scm
-        buildout -n
+        pip install -U tox
 
     - name: Test
       env:
         AMQP_RABBITMQCTL: docker exec $(docker ps -aqf "label=rabbitmq") rabbitmqctl
       run: |
-        bin/test --cache-clear --cov-report term-missing --cov src
+        tox -e py

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,8 @@
 CHANGES
 =======
 
-2.1 (unreleased)
-----------------
+2.1a2 (unreleased)
+------------------
 
 - Nothing changed yet.
 

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,25 +1,10 @@
 [buildout]
 develop = .
-parts = scripts pytest omelette send_files
+parts = scripts omelette send_files
 find-links = http://download.gocept.com/packages/
 package = gocept.amqprun
 allow-picked-versions = true
 show-picked-versions = false
-
-[pytest]
-recipe = zc.recipe.egg
-scripts = py.test=test
-test-eggs = ${buildout:package} [test,readfiles,security]
-eggs = gocept.pytestlayer
-       pytest >= 4.6, < 5
-       pytest-cache
-       pytest-cov
-       pytest-rerunfailures < 8
-       pytest-flake8
-       pytest-remove-stale-bytecode
-       pytest-instafail
-       zipp < 2
-       ${:test-eggs}
 
 [scripts]
 scripts =
@@ -41,4 +26,4 @@ arguments =
 
 [omelette]
 recipe = collective.recipe.omelette
-eggs = ${pytest:test-eggs}
+eggs = ${buildout:package} [test,readfiles,security]

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ tests_require = (
 
 setup(
     name='gocept.amqprun',
-    version='2.1.dev0',
+    version='2.1a2.dev0',
     author='gocept <mail at gocept dot com>',
     author_email='mail@gocept.com',
     url='https://github.com/NativeInstruments/gocept.amqprun',

--- a/src/gocept/amqprun/tests/test_session.py
+++ b/src/gocept/amqprun/tests/test_session.py
@@ -228,11 +228,9 @@ class DataManagerTest(unittest.TestCase):
 class SessionTest(unittest.TestCase):
 
     def setUp(self):
-        self.patcher = mock.patch('gocept.amqprun.session.AMQPDataManager')
-        self.patcher.__enter__()
-
-    def tearDown(self):
-        self.patcher.__exit__()
+        patcher = mock.patch('gocept.amqprun.session.AMQPDataManager')
+        patcher.start()
+        self.addCleanup(patcher.stop)
 
     def create_session(self, message=None):
         from gocept.amqprun.session import Session

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,8 @@ deps =
     py27: pytest-remove-stale-bytecode < 5
     !py27: pytest-remove-stale-bytecode
     py27: zipp < 2
-    gocept.pytestlayer
+    py27: gocept.pytestlayer < 7
+    !py27: gocept.pytestlayer
     pytest-cache
     pytest-cov
     pytest-flake8

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ extras =
     test
     readfiles
     security
+passenv: AMQP_RABBITMQCTL
 deps =
     py27: pytest >= 4.6, < 5
     !py27: pytest


### PR DESCRIPTION
This is needed because we have `>= 2.1a1` as version constraint in a project.

Additionally I fixed the tests which were broken in CI and not ran using `tox` as it is the case locally.