### PR TITLE
Clean up residual code for re-connection.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ CHANGES
 2.1a2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Let the Server exit in case of an ``socket.error``. We lost the re-connection
+  feature in 2.0 already.
 
 
 2.1a1 (2020-04-17)

--- a/src/gocept/amqprun/server.py
+++ b/src/gocept/amqprun/server.py
@@ -93,8 +93,7 @@ class Server(object):
                     consumer(message)
         except socket.error:
             log.error("Error while pulling messages", exc_info=True)
-            self.channel = None
-            return
+            raise
         if time.time() - self._channel_opened > self.CHANNEL_LIFE_TIME:
             self.switch_channel()
 
@@ -110,12 +109,7 @@ class Server(object):
     def open_channel(self):
         assert self.channel is None
         log.debug('Opening new channel')
-        try:
-            self.channel = self.connection.channel()
-        except Exception:
-            log.debug('Opening new channel aborted due to closed connection,'
-                      ' since a reconnect should happen soon anyway.')
-            return
+        self.channel = self.connection.channel()
         self.bound_consumers = self._declare_and_bind_queues()
         self._channel_opened = time.time()
 
@@ -126,8 +120,6 @@ class Server(object):
         log.info('Switching to a new channel')
         try:
             self.channel.close()
-        except socket.error:
-            return
         finally:
             self.channel = None
         self.open_channel()


### PR DESCRIPTION
We do not support that anymore and, therefore, want the process to stop in a case of an socket.error.