### PR TITLE
Python 3 only

### DIFF
--- a/.github/workflows/gocept.amqprun.yml
+++ b/.github/workflows/gocept.amqprun.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.7, 3.8]
+        python-version: [3.7, 3.8]
 
     services:
       rabbitmq:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,13 @@
 CHANGES
 =======
 
-2.2 (unreleased)
+3.0 (unreleased)
 ----------------
 
-- Nothing changed yet.
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+- Drop support for Python 2.7.
 
 
 2.1 (2020-09-18)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [bdist_wheel]
-universal = 1
+universal = 0

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ install_requires = [
     'ZConfig',
     'kombu',
     'setuptools',
-    'six',
     'transaction',
     'zope.component[zcml]',
     'zope.configuration',
@@ -31,16 +30,14 @@ tests_require = (
     readfiles_require +
     security_require + [
         'gocept.testing',
-        'mock>=0.8.0, < 4 ; python_version=="2.7"',  # PY2
         'plone.testing',
         'zope.testing',
-        'zipp < 2 ; python_version=="2.7"',  # PY2
     ])
 
 
 setup(
     name='gocept.amqprun',
-    version='2.2.dev0',
+    version='3.0.dev0',
     author='gocept <mail at gocept dot com>',
     author_email='mail@gocept.com',
     url='https://github.com/NativeInstruments/gocept.amqprun',
@@ -67,11 +64,10 @@ setup(
         'License :: OSI Approved',
         'Natural Language :: English',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python',
         'Topic :: Software Development :: Libraries :: Application Frameworks',
@@ -79,6 +75,7 @@ setup(
     ],
     license='ZPL',
     namespace_packages=['gocept'],
+    python_requires='>=3.7, <4',
     install_requires=install_requires,
     extras_require=dict(
         test=tests_require,

--- a/src/gocept/amqprun/handler.py
+++ b/src/gocept/amqprun/handler.py
@@ -130,7 +130,7 @@ class ErrorHandlingHandler:
     def _format_traceback(self):
         class_, exc, tb = sys.exc_info()
         message = str(exc).replace('\x00', '')
-        message = '{}: {}'.format(class_.__name__, message)
+        message = f'{class_.__name__}: {message}'
         detail = ''.join(
             traceback.format_exception(class_, exc, tb)).replace(
                 '\x00', '')

--- a/src/gocept/amqprun/handler.py
+++ b/src/gocept/amqprun/handler.py
@@ -11,7 +11,7 @@ log = logging.getLogger(__name__)
 
 
 @zope.interface.implementer(gocept.amqprun.interfaces.IHandler)
-class Handler(object):
+class Handler:
 
     def __init__(self, queue_name, routing_key, handler_function,
                  arguments=None, principal=None):
@@ -31,7 +31,7 @@ class Handler(object):
         return self.handler_function(message) or []
 
     def __repr__(self):
-        return '<gocept.amqprun.handler.Handler(%r, %r, %r)>' % (
+        return '<gocept.amqprun.handler.Handler({!r}, {!r}, {!r})>'.format(
             self.handler_function, self.queue_name, self.routing_key)
 
 
@@ -47,7 +47,7 @@ handle = declare
 @zope.interface.implementer(
     gocept.amqprun.interfaces.IHandler,
     gocept.amqprun.interfaces.IResponse)
-class ErrorHandlingHandler(object):
+class ErrorHandlingHandler:
 
     queue_name = NotImplemented
     routing_key = NotImplemented
@@ -130,7 +130,7 @@ class ErrorHandlingHandler(object):
     def _format_traceback(self):
         class_, exc, tb = sys.exc_info()
         message = str(exc).replace('\x00', '')
-        message = '%s: %s' % (class_.__name__, message)
+        message = '{}: {}'.format(class_.__name__, message)
         detail = ''.join(
             traceback.format_exception(class_, exc, tb)).replace(
                 '\x00', '')

--- a/src/gocept/amqprun/interfaces.py
+++ b/src/gocept/amqprun/interfaces.py
@@ -119,5 +119,5 @@ class IConfigFinished(zope.interface.Interface):
 
 
 @zope.interface.implementer(IConfigFinished)
-class ConfigFinished(object):
+class ConfigFinished:
     """Event notified when the configuration was loaded."""

--- a/src/gocept/amqprun/main.py
+++ b/src/gocept/amqprun/main.py
@@ -7,7 +7,6 @@ import pkg_resources
 import zope.component
 import zope.configuration.xmlconfig
 import zope.event
-import six
 
 
 log = logging.getLogger(__name__)
@@ -27,12 +26,7 @@ def create_configured_server(config_file):
     settings = gocept.amqprun.settings.Settings()
     zope.component.provideUtility(settings)
     if conf.settings:
-        if six.PY2:
-            settings.update(
-                {six.text_type(k): six.text_type(v, 'UTF-8')
-                 for k, v in conf.settings.items()})
-        else:
-            settings.update(conf.settings.items())
+        settings.update(conf.settings.items())
 
     zope.configuration.xmlconfig.file(conf.worker.component_configuration)
 

--- a/src/gocept/amqprun/readfiles.py
+++ b/src/gocept/amqprun/readfiles.py
@@ -5,7 +5,6 @@ import logging
 import os
 import os.path
 import signal
-import six
 import time
 import transaction
 import zope.component
@@ -18,14 +17,13 @@ import zope.schema
 log = logging.getLogger(__name__)
 
 
-class FileStoreReader(object):
+class FileStoreReader:
 
     def __init__(self, path, routing_key):
         self.routing_key = routing_key
         self.filestore = gocept.filestore.FileStore(path)
         self.filestore.prepare()
         self.session = Session(self)
-        super(FileStoreReader, self).__init__()
 
     def run(self):
         log.info('starting to watch %s', self.filestore.path)
@@ -40,7 +38,7 @@ class FileStoreReader(object):
     def scan(self):
         for filename in self.filestore.list('new'):
             transaction.begin()
-            log.info('sending %r to %r' % (filename, self.routing_key))
+            log.info('sending %r to %r', filename, self.routing_key)
             try:
                 self.send(filename)
                 self.session.mark_done(filename)
@@ -58,7 +56,7 @@ class FileStoreReader(object):
             'content_type': 'text/xml',
             'X-Filename': os.path.basename(filename).encode('utf-8'),
         }
-        if six.PY3 and isinstance(body, str):
+        if isinstance(body, str):
             headers['content_encoding'] = 'utf-8'
         message = gocept.amqprun.message.Message(
             headers, body, routing_key=self.routing_key)
@@ -66,7 +64,7 @@ class FileStoreReader(object):
         sender.send(message)
 
 
-class Session(object):
+class Session:
 
     def __init__(self, context):
         self.files = []
@@ -95,7 +93,7 @@ class Session(object):
 
 
 @zope.interface.implementer(transaction.interfaces.IDataManager)
-class FileStoreDataManager(object):
+class FileStoreDataManager:
 
     def __init__(self, session):
         self.session = session

--- a/src/gocept/amqprun/session.py
+++ b/src/gocept/amqprun/session.py
@@ -9,7 +9,7 @@ log = logging.getLogger(__name__)
 
 
 @zope.interface.implementer(gocept.amqprun.interfaces.ISession)
-class Session(object):
+class Session:
 
     def __init__(self, channel, received_message=None):
         self.messages = []
@@ -67,7 +67,7 @@ class Session(object):
 
 
 @zope.interface.implementer(transaction.interfaces.ISavepointDataManager)
-class AMQPDataManager(object):
+class AMQPDataManager:
 
     transaction_manager = None
 
@@ -126,12 +126,12 @@ class AMQPDataManager(object):
         return NoOpSavepoint()
 
     def __repr__(self):
-        return '<gocept.amqprun.session.DataManager for %s, %s>' % (
+        return '<gocept.amqprun.session.DataManager for {}, {}>'.format(
             transaction.get(), self.session)
 
 
 @zope.interface.implementer(transaction.interfaces.IDataManagerSavepoint)
-class NoOpSavepoint(object):
+class NoOpSavepoint:
 
     def rollback(self):
         pass

--- a/src/gocept/amqprun/testing.py
+++ b/src/gocept/amqprun/testing.py
@@ -69,12 +69,12 @@ class QueueLayer(plone.testing.Layer):
             del self['amqp-virtualhost-created']
 
     def rabbitmqctl(self, parameter):
-        command = '{} {}'.format(self.RABBITMQCTL_COMMAND, parameter)
+        command = f'{self.RABBITMQCTL_COMMAND} {parameter}'
         stdout = subprocess.check_output(
             'LANG=C %s' % command, stderr=subprocess.STDOUT, shell=True)
         if b'Error' in stdout:
             raise RuntimeError(
-                '{} failed:\n{}'.format(command, stdout))  # pragma: no cover
+                f'{command} failed:\n{stdout}')  # pragma: no cover
 
 
 QUEUE_LAYER = QueueLayer()

--- a/src/gocept/amqprun/tests/basic.py
+++ b/src/gocept/amqprun/tests/basic.py
@@ -5,7 +5,6 @@ import gocept.amqprun.message
 import gocept.amqprun.interfaces
 import transaction
 import zope.component
-from six.moves import range
 
 
 log = logging.getLogger(__name__)

--- a/src/gocept/amqprun/tests/integration.py
+++ b/src/gocept/amqprun/tests/integration.py
@@ -26,7 +26,7 @@ handler_error = gocept.amqprun.handler.Handler(
 
 
 @zope.interface.implementer(gocept.amqprun.interfaces.IResponse)
-class Response(object):
+class Response:
 
     responses = []
     _exception = False

--- a/src/gocept/amqprun/tests/test_handler.py
+++ b/src/gocept/amqprun/tests/test_handler.py
@@ -1,11 +1,7 @@
+from unittest import mock
 import gocept.testing.assertion
 import unittest
 import zope.interface.verify
-
-try:
-    from unittest import mock
-except ImportError:  # PY2
-    import mock
 
 
 class TestHandler(unittest.TestCase):

--- a/src/gocept/amqprun/tests/test_main.py
+++ b/src/gocept/amqprun/tests/test_main.py
@@ -1,4 +1,4 @@
-# coding: utf8
+from unittest import mock
 import gocept.amqprun.interfaces
 import gocept.amqprun.message
 import gocept.amqprun.session
@@ -6,18 +6,12 @@ import gocept.amqprun.testing
 import gocept.amqprun.tests.integration
 import logging
 import zope.component
-import six
-
-try:
-    from unittest import mock
-except ImportError:  # PY2
-    import mock
 
 
 class ReceiveMessages(gocept.amqprun.testing.MainTestCase):
 
     def setUp(self):
-        super(ReceiveMessages, self).setUp()
+        super().setUp()
         self.messages_received = []
         gocept.amqprun.tests.integration.messages_received = (
             self.messages_received)
@@ -28,7 +22,7 @@ class ReceiveMessages(gocept.amqprun.testing.MainTestCase):
 
     def tearDown(self):
         gocept.amqprun.tests.integration.messages_received = None
-        super(ReceiveMessages, self).tearDown()
+        super().tearDown()
 
     def test_message_should_be_processed(self):
         self.assertEquals([], self.messages_received)
@@ -73,7 +67,7 @@ class ReceiveMessages(gocept.amqprun.testing.MainTestCase):
 class ConfigLoadingTest(gocept.amqprun.testing.MainTestCase):
 
     def setUp(self):
-        super(ConfigLoadingTest, self).setUp()
+        super().setUp()
         self.patchers = []
         patcher = mock.patch('gocept.amqprun.server.Server')
         self.server = patcher.start()
@@ -88,7 +82,7 @@ class ConfigLoadingTest(gocept.amqprun.testing.MainTestCase):
     def tearDown(self):
         for patcher in self.patchers:
             patcher.stop()
-        super(ConfigLoadingTest, self).tearDown()
+        super().tearDown()
 
     def test_basic_configuration_should_load_zcml(self):
         import gocept.amqprun.interfaces
@@ -132,8 +126,8 @@ class ConfigLoadingTest(gocept.amqprun.testing.MainTestCase):
         gocept.amqprun.main.main(config)
         settings = zope.component.getUtility(
             gocept.amqprun.interfaces.ISettings)
-        self.assertIsInstance(settings.get('test.setting.1'), six.text_type)
-        self.assertEquals(u'Ümläuten', settings.get('test.setting.unicode'))
+        self.assertIsInstance(settings.get('test.setting.1'), str)
+        self.assertEquals('Ümläuten', settings.get('test.setting.unicode'))
 
     def test_settings_should_allow_upper_case(self):
         import gocept.amqprun.interfaces

--- a/src/gocept/amqprun/tests/test_message.py
+++ b/src/gocept/amqprun/tests/test_message.py
@@ -1,9 +1,7 @@
-# -*- coding: utf-8 -*-
 from datetime import datetime
 from gocept.amqprun.message import Properties, Message
 import gocept.testing.assertion
 import pytest
-import six
 import time
 import unittest
 import zope.interface.verify
@@ -19,9 +17,9 @@ class TestMessage(unittest.TestCase):
         self.assertEqual(b'body', message.body)
         self.assertEqual('amq.topic', message.exchange)
 
-    def test_message_can_be_unicode_if_encoding_is_set(self):
-        message = Message({'content_encoding': 'utf-8'}, u'bödÿ')
-        self.assertEqual(u'bödÿ', message.body)
+    def test_message_can_be_text_if_encoding_is_set(self):
+        message = Message({'content_encoding': 'utf-8'}, 'bödÿ')
+        self.assertEqual('bödÿ', message.body)
 
     def test_header_should_be_converted_to_Properties(self):
         now = int(time.time())
@@ -46,19 +44,12 @@ class TestMessage(unittest.TestCase):
         message = Message(dict(message_id='myid'), b'')
         self.assertEqual('myid', message.header.message_id)
 
-    def test_message_with_unicode_body_needs_content_encoding(self):
+    def test_message_with_text_body_needs_content_encoding(self):
         with pytest.raises(ValueError):
-            Message({}, u'Test')
-        message = Message({'content_encoding': 'UTF-8'}, u'Test')
+            Message({}, 'Test')
+        message = Message({'content_encoding': 'UTF-8'}, 'Test')
 
         assert message
-
-    @pytest.mark.skipif(
-        six.PY3, reason='There is no special handling on Python 3')
-    def test_message_with_empty_unicode_body_gets_empty_string_body(self):
-        message = Message({}, u'')
-
-        assert isinstance(message.body, str)
 
     def test_message_additional_application_headers_get_merged(self):
         headers = {

--- a/src/gocept/amqprun/tests/test_readfiles.py
+++ b/src/gocept/amqprun/tests/test_readfiles.py
@@ -1,4 +1,5 @@
 from gocept.amqprun.readfiles import FileStoreReader, FileStoreDataManager
+from unittest import mock
 import gocept.amqprun.interfaces
 import gocept.amqprun.testing
 import os
@@ -8,16 +9,11 @@ import unittest
 import zope.component
 import time
 
-try:
-    from unittest import mock
-except ImportError:  # PY2
-    import mock
-
 
 class ReaderTest(unittest.TestCase):
 
     def setUp(self):
-        super(ReaderTest, self).setUp()
+        super().setUp()
         self.sender = mock.Mock()
         zope.component.provideUtility(
             self.sender, gocept.amqprun.interfaces.ISender)
@@ -25,7 +21,7 @@ class ReaderTest(unittest.TestCase):
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir)
-        super(ReaderTest, self).tearDown()
+        super().tearDown()
 
     def test_empty_new_directory_nothing_happens(self):
         reader = FileStoreReader(self.tmpdir, 'route')
@@ -81,11 +77,11 @@ class FileStoreDataManagerTest(unittest.TestCase):
 class ReaderIntegrationTest(gocept.amqprun.testing.MainTestCase):
 
     def setUp(self):
-        super(ReaderIntegrationTest, self).setUp()
+        super().setUp()
         self.tmpdir = tempfile.mkdtemp()
 
     def tearDown(self):
-        super(ReaderIntegrationTest, self).tearDown()
+        super().tearDown()
         shutil.rmtree(self.tmpdir)
 
     def wait_for_directory_present(self, path, timeout=10):

--- a/src/gocept/amqprun/tests/test_sender.py
+++ b/src/gocept/amqprun/tests/test_sender.py
@@ -5,7 +5,7 @@ import transaction
 class MessageSenderTest(gocept.amqprun.testing.QueueTestCase):
 
     def setUp(self):
-        super(MessageSenderTest, self).setUp()
+        super().setUp()
         transaction.abort()
         self.expect_message_on('test.key')
         self.sender = self.create_server()

--- a/src/gocept/amqprun/tests/test_server.py
+++ b/src/gocept/amqprun/tests/test_server.py
@@ -1,4 +1,5 @@
 from gocept.amqprun.server import Parameters
+from unittest import mock
 import amqp
 import collections
 import gocept.amqprun.handler
@@ -11,11 +12,6 @@ import time
 import unittest
 import zope.component
 import zope.interface
-
-try:
-    from unittest import mock
-except ImportError:  # PY2
-    import mock
 
 
 class ParametersTest(unittest.TestCase):
@@ -105,8 +101,8 @@ class MessageReaderTest(gocept.amqprun.testing.QueueTestCase):
         import gocept.amqprun.interfaces
 
         @zope.interface.provider(gocept.amqprun.interfaces.IHandler)
-        class Handler(object):
-            queue_name = self.get_queue_name(u'test.case.2')
+        class Handler:
+            queue_name = self.get_queue_name('test.case.2')
             routing_key = 'test.messageformat.2'
             arguments = {}
         zope.component.provideUtility(Handler, name='handler')
@@ -116,9 +112,9 @@ class MessageReaderTest(gocept.amqprun.testing.QueueTestCase):
         import gocept.amqprun.interfaces
 
         @zope.interface.provider(gocept.amqprun.interfaces.IHandler)
-        class Handler(object):
+        class Handler:
             queue_name = self.get_queue_name('test.case.2')
-            routing_key = u'test.messageformat.2'
+            routing_key = 'test.messageformat.2'
             arguments = {}
         zope.component.provideUtility(Handler, name='handler')
         self.start_server()
@@ -127,10 +123,10 @@ class MessageReaderTest(gocept.amqprun.testing.QueueTestCase):
         import gocept.amqprun.interfaces
 
         @zope.interface.provider(gocept.amqprun.interfaces.IHandler)
-        class Handler(object):
+        class Handler:
             queue_name = self.get_queue_name('test.case.2')
             routing_key = 'test.messageformat.2'
-            arguments = {u'x-ha-policy': u'all'}
+            arguments = {'x-ha-policy': 'all'}
         zope.component.provideUtility(Handler, name='handler')
         self.start_server()
 
@@ -139,7 +135,7 @@ class MessageReaderTest(gocept.amqprun.testing.QueueTestCase):
         import transaction
         self.start_server()
         self.server.send(gocept.amqprun.message.Message(
-            {}, b'body', routing_key=u'test.routing'))
+            {}, b'body', routing_key='test.routing'))
         transaction.commit()
 
     def test_unicode_body_should_work_for_message(self):
@@ -148,7 +144,7 @@ class MessageReaderTest(gocept.amqprun.testing.QueueTestCase):
         self.start_server()
         self.server.send(gocept.amqprun.message.Message(
             {'content_encoding': 'UTF-8'},
-            u'body',
+            'body',
             routing_key='test.routing'))
         transaction.commit()
 
@@ -157,9 +153,9 @@ class MessageReaderTest(gocept.amqprun.testing.QueueTestCase):
         import transaction
         self.start_server()
         self.server.send(gocept.amqprun.message.Message(
-            {u'content_type': u'text/plain',
-             u'content_encoding': u'utf-8'},
-            u'body', routing_key='test.routing'))
+            {'content_type': 'text/plain',
+             'content_encoding': 'utf-8'},
+            'body', routing_key='test.routing'))
         transaction.commit()
 
     def test_multiple_routing_keys_should_recieve_messages_for_all(self):
@@ -259,7 +255,7 @@ class TestChannelSwitch(unittest.TestCase):
 class DyingRabbitTest(gocept.amqprun.testing.QueueTestCase):
 
     def setUp(self):
-        super(DyingRabbitTest, self).setUp()
+        super().setUp()
         self.handler = gocept.amqprun.handler.Handler(
             'test.queuename',
             'test.routingkey', mock.Mock())
@@ -268,7 +264,7 @@ class DyingRabbitTest(gocept.amqprun.testing.QueueTestCase):
     def tearDown(self):
         gsm = zope.component.getSiteManager()
         gsm.unregisterUtility(self.handler)
-        super(DyingRabbitTest, self).tearDown()
+        super().tearDown()
 
     def start_server(self):
         self.server = self.create_server()
@@ -313,7 +309,7 @@ class EndToEndTest(gocept.amqprun.testing.MainTestCase):
     """Testing .server.Server when started in a seperate subprocess."""
 
     def setUp(self):
-        super(EndToEndTest, self).setUp()
+        super().setUp()
         self.make_config(__name__, 'server')
         self.expect_message_on('test.echoed')
         self.start_server_in_subprocess()
@@ -321,7 +317,7 @@ class EndToEndTest(gocept.amqprun.testing.MainTestCase):
 
     def tearDown(self):
         self.stop_server_in_subprocess()
-        super(EndToEndTest, self).tearDown()
+        super().tearDown()
 
     def wait_for_queue_declared(self, queue_name, timeout=5):
         wait = 0

--- a/src/gocept/amqprun/tests/test_session.py
+++ b/src/gocept/amqprun/tests/test_session.py
@@ -1,3 +1,4 @@
+from unittest import mock
 import amqp.channel
 import gocept.amqprun.message
 import threading
@@ -7,11 +8,6 @@ import unittest
 import zope.component
 import zope.component.testing
 import zope.interface.verify
-
-try:
-    from unittest import mock
-except ImportError:  # PY2
-    import mock
 
 
 class DataManagerTest(unittest.TestCase):

--- a/src/gocept/amqprun/tests/test_worker.py
+++ b/src/gocept/amqprun/tests/test_worker.py
@@ -1,13 +1,9 @@
+from unittest import mock
 import gocept.amqprun.handler
 import gocept.amqprun.interfaces
 import gocept.amqprun.worker
 import unittest
 import zope.interface
-
-try:
-    from unittest import mock
-except ImportError:  # PY2
-    import mock
 
 
 class WorkerTest(unittest.TestCase):

--- a/src/gocept/amqprun/worker.py
+++ b/src/gocept/amqprun/worker.py
@@ -18,7 +18,7 @@ except ImportError:  # pragma: no cover
 log = logging.getLogger(__name__)
 
 
-class PrefixingLogger(object):
+class PrefixingLogger:
     """Convenience for spelling log.foo(prefix + message)"""
 
     def __init__(self, log, prefix):
@@ -32,7 +32,7 @@ class PrefixingLogger(object):
         return write
 
 
-class Worker(object):
+class Worker:
 
     def __init__(self, session, handler):
         self.session = session

--- a/tox.ini
+++ b/tox.ini
@@ -1,29 +1,23 @@
 [tox]
 envlist =
-    py27
     py37
     py38
 
 [testenv]
 usedevelop = true
 extras =
-    test
     readfiles
     security
+    test
 passenv: AMQP_RABBITMQCTL
 deps =
-    py27: pytest >= 4.6, < 5
-    !py27: pytest
-    py27: pytest-rerunfailures < 8
-    !py27: pytest-rerunfailures
-    py27: pytest-remove-stale-bytecode < 5
-    !py27: pytest-remove-stale-bytecode
-    py27: zipp < 2
-    py27: gocept.pytestlayer < 7
-    !py27: gocept.pytestlayer
+    gocept.pytestlayer
+    pytest
     pytest-cache
     pytest-cov
     pytest-flake8
     pytest-instafail
+    pytest-remove-stale-bytecode
+    pytest-rerunfailures
 commands =
     pytest []


### PR DESCRIPTION
It is time to drop Python 2 support. This eases the handling of Exceptions during Retry-Logic.